### PR TITLE
Fixing the 2det per qubit Example

### DIFF
--- a/Tests/test_example_2q2d.py
+++ b/Tests/test_example_2q2d.py
@@ -1,0 +1,40 @@
+import QuantumTomography as qLib
+import numpy as np
+
+# Coincidence counts for 9 measurements.
+# Each row is the coincidence counts for detector pairs 1,2,3 and 4 respectfully
+coincidence_counts = np.array([[497, 0, 0, 503],
+                               [256, 265, 250, 229],
+                               [235, 268, 242, 255],
+                               [254, 262, 249, 235],
+                               [521, 0, 0, 479],
+                               [235, 268, 248, 249],
+                               [265, 229, 280, 226],
+                               [253, 242, 247, 258],
+                               [0, 495, 505, 0]])
+
+# Measurement basis for 9 measurements
+# In each row the first two (possible complex) numbers alpha and beta represent the state that the first qubit
+# is projected onto when it ends up at detector 1.
+# The next two numbers is the state the second qubit is projected onto when it ends up at detector 2.
+measurements = np.array([[1 + 0j, 0j, 1 + 0j, 0j],
+                         [1 + 0j, 0j, 0.70710678 + 0j, 0.7071067811865476 + 0j],
+                         [1 + 0j, 0j, 0.70710678 + 0j, 0.70710678j],
+                         [0.70710678 + 0j, 0.70710678 + 0j, 1 + 0j, 0j],
+                         [0.70710678 + 0j, 0.70710678 + 0j, 0.70710678 + 0j, 0.70710678 + 0j],
+                         [0.70710678 + 0j, 0.70710678 + 0j, 0.70710678 + 0j, 0.70710678j],
+                         [0.70710678 + 0j, 0.70710678j, 1 + 0j, 0j],
+                         [0.70710678 + 0j, 0.70710678j, 0.70710678 + 0j, 0.70710678 + 0j],
+                         [0.70710678 + 0j, 0.70710678j, 0.70710678 + 0j, 0.7071067811865476j], ])
+
+# Initiate tomography object
+tomo_obj = qLib.Tomography()
+
+# Run tomography
+[rho_approx, intensity, fval] = tomo_obj.StateTomography(measurements, coincidence_counts)
+
+# Print Results
+tomo_obj.printLastOutput()
+print('----------------')
+bell_state = 1 / np.sqrt(2) * np.array([1, 0, 0, 1], dtype=complex)
+print('Fidelity with actual : ' + str(qLib.fidelity(bell_state, rho_approx)))

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def readme():
 
 setup(
     name = "Quantum-Tomography",
-    version = "1.0.5.0",
+    version = "1.0.6.0",
     description = "A python library to help perform tomography on a quantum state.",
     long_description = readme(),
     long_description_content_type = "text/markdown",

--- a/src/QuantumTomography/TomoClass.py
+++ b/src/QuantumTomography/TomoClass.py
@@ -194,7 +194,7 @@ class Tomography():
         The relative efficienies between your detector pairs.
     time :  1darray with length = Number of measurements (optional)
         The total duration of each measurment.
-    singles : ndarray shape = ( Number of measurements , 2*NQubits ) (optional)
+    singles : ndarray shape = ( Number of measurements , NDetectors*NQubits ) (optional)
         The singles counts on each detector.
     window : 1darray with length = NQubits*NDetectors (optional)
         The coincidence window duration for each detector pair.
@@ -227,7 +227,7 @@ class Tomography():
     Parameters
     ----------
     tomo_input : ndarray
-        The input data for the current tomography. Example can be seen at top of page.
+        The input data for the current tomography.
     intensities : 1darray with length = number of measurements (optional)
         Relative pump power (arb. units) during measurement; used for drift correction. Default will be an array of ones
     method : ['MLE','HMLE','BME','LINER'] (optional)
@@ -769,7 +769,7 @@ class Tomography():
     Parameters
     ----------
     tomo_input : ndarray
-        The input data for the current tomography. Example can be seen at top of page.
+        The input data for the current tomography.
 
     Returns
     -------
@@ -980,7 +980,7 @@ class Tomography():
                 raise ValueError("Invalid window array")
         else:
             time = np.ones(measurements.shape[0])
-            singles = np.zeros((measurements.shape[0],self.conf["NQubits"]))
+            singles = np.zeros((measurements.shape[0],self.getNumSingles()))
             self.conf['Window'] = window
 
 
@@ -1025,7 +1025,6 @@ class Tomography():
             # measurements
             tomo_input[:, 2 ** n_qubit + 2 * n_qubit + 1: 2 ** n_qubit + 4 * n_qubit + 1] = measurements
 
-
         return tomo_input
 
     """
@@ -1051,7 +1050,7 @@ class Tomography():
         elif self.conf['NDetectors'] == 2:
             try:
                 eff = np.array(self.conf['Efficiency'],dtype=float)
-                if isinstance(eff,int):
+                if isinstance(self.conf['Efficiency'],int):
                     eff = np.ones(self.getNumCoinc())
                 if len(eff.shape) != 1 or len(eff) != self.getNumCoinc():
                     raise
@@ -1149,10 +1148,7 @@ class Tomography():
     Desc: Returns the number of singles per measurement for the current configurations.
     """
     def getNumSingles(self):
-        if (self.conf['NDetectors'] == 2):
-            return 2 * self.conf['NQubits']
-        else:
-            return self.conf['NQubits']
+        return self.conf['NDetectors']*self.conf['NQubits']
 
     """
     getNumDetPerQubit()
@@ -1223,7 +1219,7 @@ class Tomography():
     Returns
     -------
     Tomoinput : ndarray
-        The input data for the current tomography.Example can be seen at top of page.
+        The input data for the current tomography.
     """
     def getTomoInputTemplate(self, numBits = -1,numDet = -1):
         # check if numBits is an int


### PR DESCRIPTION
When running the 2det per quibit example available on our website https://quantumtomo.web.illinois.edu/Algorithm/example_2qubit4det the code was throwing an error. When parsing the input it was expected the wrong size for the singles and efficiency matrix. fixes #34  Minor comment updates for the website